### PR TITLE
Fix Acquire typo

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -26,7 +26,7 @@ var (
 
 			switch configFlag {
 			case "browser":
-				browserToolDefinition, err := tools.Aquire("web-browsing")
+				browserToolDefinition, err := tools.Acquire("web-browsing")
 				if err != nil {
 					return fmt.Errorf("failed to acquire browser tool definition: %w", err)
 				}
@@ -40,7 +40,7 @@ var (
 				log.Info("Registered 'browser' tool with MCP server", "hostname", hostname)
 
 			case "docker":
-				dockerToolDefinition, err := tools.Aquire("development")
+				dockerToolDefinition, err := tools.Acquire("development")
 				if err != nil {
 					return fmt.Errorf("failed to acquire docker tool definition: %w", err)
 				}

--- a/pkg/a2a/card.go
+++ b/pkg/a2a/card.go
@@ -56,7 +56,7 @@ type AgentSkill struct {
 }
 
 func (skill *AgentSkill) ToMCPTool() (*mcp.Tool, error) {
-	return tools.Aquire(skill.ID)
+	return tools.Acquire(skill.ID)
 }
 
 // AgentCard represents the metadata card for an agent

--- a/pkg/tools/mcp.go
+++ b/pkg/tools/mcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func Aquire(id string) (*mcp.Tool, error) {
+func Acquire(id string) (*mcp.Tool, error) {
 	log.Info("initializing MCP client")
 
 	switch id {


### PR DESCRIPTION
## Summary
- rename `Aquire` to `Acquire`
- update call sites in `cmd/mcp.go` and `pkg/a2a/card.go`

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.2)*
- `go build ./...` *(fails: go.mod requires go >= 1.24.2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in the tool acquisition function name to ensure proper tool retrieval in relevant features. No changes to user-facing logic or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->