### PR TITLE
Fix division by zero bug in streaming metrics

### DIFF
--- a/pkg/metrics/streaming.go
+++ b/pkg/metrics/streaming.go
@@ -64,6 +64,14 @@ func (m *StreamingMetrics) GetMetrics() map[string]any {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	avgEventLatency := 0.0
+	avgProcessingTime := 0.0
+
+	if m.TotalEvents > 0 {
+		avgEventLatency = m.EventLatency.Seconds() / float64(m.TotalEvents)
+		avgProcessingTime = m.ProcessingTime.Seconds() / float64(m.TotalEvents)
+	}
+
 	return map[string]any{
 		"total_connections":   m.TotalConnections,
 		"failed_connections":  m.FailedConnections,
@@ -71,7 +79,7 @@ func (m *StreamingMetrics) GetMetrics() map[string]any {
 		"connection_duration": m.ConnectionDuration.Seconds(),
 		"total_events":        m.TotalEvents,
 		"dropped_events":      m.DroppedEvents,
-		"avg_event_latency":   m.EventLatency.Seconds() / float64(m.TotalEvents),
-		"avg_processing_time": m.ProcessingTime.Seconds() / float64(m.TotalEvents),
+		"avg_event_latency":   avgEventLatency,
+		"avg_processing_time": avgProcessingTime,
 	}
 }


### PR DESCRIPTION
## Summary
- handle zero events correctly when computing streaming metrics

## Testing
- `go build ./...` *(fails: go1.24.2 download blocked)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a potential issue that could cause errors when viewing average event latency and processing time metrics if no events have occurred. These averages will now safely display as zero when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->