### PR TITLE
Add basic unified memory framework

### DIFF
--- a/pkg/a2a/task.go
+++ b/pkg/a2a/task.go
@@ -105,6 +105,14 @@ func (task *Task) LastMessage() *Message {
 	return &task.History[len(task.History)-1]
 }
 
+func (task *Task) AddMessage(role, name, text string) {
+	task.History = append(task.History, Message{
+		Role:     role,
+		Parts:    []Part{{Type: PartTypeText, Text: text}},
+		Metadata: map[string]any{"name": name},
+	})
+}
+
 func (task *Task) AddArtifact(artifact Artifact) {
 	task.Artifacts = append(task.Artifacts, artifact)
 }

--- a/pkg/memory/interfaces.go
+++ b/pkg/memory/interfaces.go
@@ -1,0 +1,51 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/theapemachine/a2a-go/pkg/a2a"
+)
+
+// Embedder represents a service capable of generating embeddings.
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+}
+
+// VectorStore provides semantic search capabilities over memories.
+type VectorStore interface {
+	StoreMemory(ctx context.Context, memory Memory) (string, error)
+	StoreMemories(ctx context.Context, memories []Memory) error
+	GetMemory(ctx context.Context, id string) (Memory, error)
+	SearchSimilar(ctx context.Context, embedding []float32, params SearchParams) ([]Memory, error)
+	DeleteMemory(ctx context.Context, id string) error
+	Ping(ctx context.Context) error
+}
+
+// GraphStore manages relationships between memories.
+type GraphStore interface {
+	StoreMemory(ctx context.Context, memory Memory) (string, error)
+	CreateRelation(ctx context.Context, relation Relation) error
+	GetMemory(ctx context.Context, id string) (Memory, error)
+	FindRelated(ctx context.Context, id string, relationTypes []string, limit int) ([]Memory, error)
+	QueryGraph(ctx context.Context, query string, params map[string]any) ([]Memory, error)
+	DeleteMemory(ctx context.Context, id string) error
+	DeleteRelation(ctx context.Context, source, target, relationType string) error
+	Ping(ctx context.Context) error
+}
+
+// UnifiedStore exposes a combined interface for vector and graph stores.
+type UnifiedStore interface {
+	StoreMemory(ctx context.Context, content string, metadata map[string]any, memType string) (string, error)
+	CreateRelation(ctx context.Context, source, target, relationType string, properties map[string]any) error
+	SearchSimilar(ctx context.Context, query string, params SearchParams) ([]Memory, error)
+	FindRelated(ctx context.Context, id string, relationTypes []string, limit int) ([]Memory, error)
+	InjectMemories(ctx context.Context, task TaskLike) error
+	ExtractMemories(ctx context.Context, task TaskLike) error
+}
+
+// TaskLike captures the subset of task operations needed by the memory system.
+type TaskLike interface {
+	AddMessage(role, name, text string)
+	LastMessage() *a2a.Message
+}

--- a/pkg/memory/neo4j_store.go
+++ b/pkg/memory/neo4j_store.go
@@ -1,0 +1,109 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/theapemachine/a2a-go/pkg/stores/neo4j"
+)
+
+// Neo4jGraphStore implements GraphStore using Neo4j.
+type Neo4jGraphStore struct {
+	client *neo4j.Client
+}
+
+func NewNeo4jGraphStore(endpoint, user, pass string) *Neo4jGraphStore {
+	return &Neo4jGraphStore{client: neo4j.New(endpoint, user, pass)}
+}
+
+func (s *Neo4jGraphStore) StoreMemory(ctx context.Context, mem Memory) (string, error) {
+	if mem.ID == "" {
+		mem.ID = uuid.NewString()
+	}
+	md, _ := json.Marshal(mem.Metadata)
+	_, err := s.client.ExecCypher(ctx,
+		"MERGE (m:Memory {id:$id}) SET m.content=$content, m.type=$type, m.metadata=$metadata RETURN m.id",
+		map[string]any{"id": mem.ID, "content": mem.Content, "type": mem.Type, "metadata": string(md)})
+	if err != nil {
+		return "", err
+	}
+	return mem.ID, nil
+}
+
+func (s *Neo4jGraphStore) CreateRelation(ctx context.Context, rel Relation) error {
+	props, _ := json.Marshal(rel.Properties)
+	_, err := s.client.ExecCypher(ctx,
+		fmt.Sprintf("MATCH (a:Memory {id:$source}), (b:Memory {id:$target}) MERGE (a)-[r:%s {props:$props}]->(b)", rel.Type),
+		map[string]any{"source": rel.SourceID, "target": rel.TargetID, "props": string(props)})
+	return err
+}
+
+func (s *Neo4jGraphStore) GetMemory(ctx context.Context, id string) (Memory, error) {
+	out, err := s.client.ExecCypher(ctx,
+		"MATCH (m:Memory {id:$id}) RETURN m.id as id, m.content as content, m.metadata as metadata, m.type as type",
+		map[string]any{"id": id})
+	if err != nil {
+		return Memory{}, err
+	}
+	if len(out["results"].([]any)) == 0 {
+		return Memory{}, fmt.Errorf("not found")
+	}
+	row := out["results"].([]any)[0].(map[string]any)["data"].([]any)[0].(map[string]any)["row"].([]any)
+	meta := make(map[string]any)
+	_ = json.Unmarshal([]byte(row[2].(string)), &meta)
+	return Memory{ID: row[0].(string), Content: row[1].(string), Metadata: meta, Type: row[3].(string)}, nil
+}
+
+func (s *Neo4jGraphStore) FindRelated(ctx context.Context, id string, relationTypes []string, limit int) ([]Memory, error) {
+	query := "MATCH (a:Memory {id:$id})-->(b:Memory) RETURN b.id as id, b.content as content, b.metadata as metadata, b.type as type LIMIT $limit"
+	out, err := s.client.ExecCypher(ctx, query, map[string]any{"id": id, "limit": limit})
+	if err != nil {
+		return nil, err
+	}
+	rows := out["results"].([]any)[0].(map[string]any)["data"].([]any)
+	mems := make([]Memory, 0, len(rows))
+	for _, r := range rows {
+		row := r.(map[string]any)["row"].([]any)
+		meta := make(map[string]any)
+		_ = json.Unmarshal([]byte(row[2].(string)), &meta)
+		mems = append(mems, Memory{ID: row[0].(string), Content: row[1].(string), Metadata: meta, Type: row[3].(string)})
+	}
+	return mems, nil
+}
+
+func (s *Neo4jGraphStore) QueryGraph(ctx context.Context, query string, params map[string]any) ([]Memory, error) {
+	out, err := s.client.ExecCypher(ctx, query, params)
+	if err != nil {
+		return nil, err
+	}
+	rows := out["results"].([]any)[0].(map[string]any)["data"].([]any)
+	mems := make([]Memory, 0, len(rows))
+	for _, r := range rows {
+		row := r.(map[string]any)["row"].([]any)
+		meta := make(map[string]any)
+		if len(row) > 2 {
+			_ = json.Unmarshal([]byte(fmt.Sprintf("%v", row[2])), &meta)
+		}
+		mems = append(mems, Memory{ID: fmt.Sprintf("%v", row[0]), Content: fmt.Sprintf("%v", row[1]), Metadata: meta})
+	}
+	return mems, nil
+}
+
+func (s *Neo4jGraphStore) DeleteMemory(ctx context.Context, id string) error {
+	_, err := s.client.ExecCypher(ctx, "MATCH (m:Memory {id:$id}) DETACH DELETE m", map[string]any{"id": id})
+	return err
+}
+
+func (s *Neo4jGraphStore) DeleteRelation(ctx context.Context, source, target, relationType string) error {
+	_, err := s.client.ExecCypher(ctx,
+		fmt.Sprintf("MATCH (a:Memory {id:$source})-[r:%s]->(b:Memory {id:$target}) DELETE r", relationType),
+		map[string]any{"source": source, "target": target})
+	return err
+}
+
+func (s *Neo4jGraphStore) Ping(ctx context.Context) error {
+	_, err := s.client.ExecCypher(ctx, "RETURN 1", nil)
+	return err
+}

--- a/pkg/memory/qdrant_store.go
+++ b/pkg/memory/qdrant_store.go
@@ -1,0 +1,82 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/theapemachine/a2a-go/pkg/stores/qdrant"
+)
+
+// QdrantVectorStore implements VectorStore using Qdrant.
+type QdrantVectorStore struct {
+	client   *qdrant.Client
+	embedder Embedder
+}
+
+func NewQdrantVectorStore(endpoint, collection string, embedder Embedder) *QdrantVectorStore {
+	return &QdrantVectorStore{client: qdrant.New(endpoint, collection), embedder: embedder}
+}
+
+func (s *QdrantVectorStore) StoreMemory(ctx context.Context, mem Memory) (string, error) {
+	if mem.ID == "" {
+		mem.ID = uuid.NewString()
+	}
+	if mem.Embedding == nil && s.embedder != nil {
+		emb, err := s.embedder.Embed(ctx, mem.Content)
+		if err != nil {
+			return "", err
+		}
+		mem.Embedding = emb
+	}
+	md := map[string]any{"embedding": mem.Embedding, "type": mem.Type}
+	for k, v := range mem.Metadata {
+		md[k] = v
+	}
+	doc := qdrant.NewDocument(mem.ID, mem.Content, md)
+	if err := s.client.Put(ctx, []qdrant.Document{*doc}); err != nil {
+		return "", err
+	}
+	return mem.ID, nil
+}
+
+func (s *QdrantVectorStore) StoreMemories(ctx context.Context, mems []Memory) error {
+	for _, m := range mems {
+		if _, err := s.StoreMemory(ctx, m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *QdrantVectorStore) GetMemory(ctx context.Context, id string) (Memory, error) {
+	doc, err := s.client.Get(ctx, id)
+	if err != nil {
+		return Memory{}, err
+	}
+	return Memory{ID: doc.ID, Content: doc.Content, Metadata: doc.Metadata}, nil
+}
+
+func (s *QdrantVectorStore) SearchSimilar(ctx context.Context, embedding []float32, params SearchParams) ([]Memory, error) {
+	docs, err := s.client.Search(ctx, embedding, params.Limit)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Memory, 0, len(docs))
+	for _, d := range docs {
+		out = append(out, Memory{ID: d.ID, Content: d.Content, Metadata: d.Metadata})
+	}
+	return out, nil
+}
+
+func (s *QdrantVectorStore) DeleteMemory(ctx context.Context, id string) error {
+	return s.client.Delete(ctx, id)
+}
+
+func (s *QdrantVectorStore) Ping(ctx context.Context) error {
+	_, err := s.client.Search(ctx, []float32{0}, 1)
+	if err != nil {
+		return fmt.Errorf("qdrant ping failed: %w", err)
+	}
+	return nil
+}

--- a/pkg/memory/types.go
+++ b/pkg/memory/types.go
@@ -1,0 +1,32 @@
+package memory
+
+// Memory represents a single unit of stored knowledge.
+type Memory struct {
+	ID        string
+	Content   string
+	Metadata  map[string]any
+	Type      string
+	Embedding []float32
+}
+
+// Relation connects two memories in the graph store.
+type Relation struct {
+	SourceID   string
+	TargetID   string
+	Type       string
+	Properties map[string]any
+}
+
+// Filter represents an optional search filter.
+type Filter struct {
+	Field    string
+	Operator string
+	Value    any
+}
+
+// SearchParams specify vector search options.
+type SearchParams struct {
+	Limit   int
+	Types   []string
+	Filters []Filter
+}

--- a/pkg/memory/unified.go
+++ b/pkg/memory/unified.go
@@ -1,77 +1,91 @@
 package memory
 
 import (
-	"bytes"
-	"io"
-
-	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/theapemachine/a2a-go/pkg/types"
+	"context"
+	"github.com/charmbracelet/log"
 )
 
-type Store interface {
-	io.ReadWriteCloser
+// UnifiedMemory implements the UnifiedStore interface.
+type UnifiedMemory struct {
+	embedder Embedder
+	vector   VectorStore
+	graph    GraphStore
 }
 
-type UnifiedLongTerm struct {
-	stores []Store
+func NewUnifiedStore(embedder Embedder, vector VectorStore, graph GraphStore) *UnifiedMemory {
+	return &UnifiedMemory{embedder: embedder, vector: vector, graph: graph}
 }
 
-func NewUnifiedLongTerm(stores ...Store) *UnifiedLongTerm {
-	return &UnifiedLongTerm{
-		stores: stores,
+func (u *UnifiedMemory) StoreMemory(ctx context.Context, content string, metadata map[string]any, memType string) (string, error) {
+	mem := Memory{Content: content, Metadata: metadata, Type: memType}
+	id, err := u.vector.StoreMemory(ctx, mem)
+	if err != nil {
+		return "", err
 	}
+	mem.ID = id
+	if u.graph != nil {
+		if _, err := u.graph.StoreMemory(ctx, mem); err != nil {
+			log.Error("graph store", "err", err)
+		}
+	}
+	return id, nil
 }
 
-func (unified *UnifiedLongTerm) Remember(task *types.Task) error {
-	for _, artifact := range task.Artifacts {
-		for _, part := range artifact.Parts {
-			if part.Type == types.PartTypeText {
-				for _, store := range unified.stores {
-					if _, err := store.Write([]byte(part.Text)); err != nil {
-						return err
-					}
-				}
+func (u *UnifiedMemory) CreateRelation(ctx context.Context, source, target, relationType string, properties map[string]any) error {
+	if u.graph == nil {
+		return nil
+	}
+	return u.graph.CreateRelation(ctx, Relation{SourceID: source, TargetID: target, Type: relationType, Properties: properties})
+}
+
+func (u *UnifiedMemory) SearchSimilar(ctx context.Context, query string, params SearchParams) ([]Memory, error) {
+	if u.vector == nil || u.embedder == nil {
+		return nil, nil
+	}
+	emb, err := u.embedder.Embed(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	return u.vector.SearchSimilar(ctx, emb, params)
+}
+
+func (u *UnifiedMemory) FindRelated(ctx context.Context, id string, relationTypes []string, limit int) ([]Memory, error) {
+	if u.graph == nil {
+		return nil, nil
+	}
+	return u.graph.FindRelated(ctx, id, relationTypes, limit)
+}
+
+func (u *UnifiedMemory) InjectMemories(ctx context.Context, task TaskLike) error {
+	last := task.LastMessage()
+	if last == nil || u.vector == nil || u.embedder == nil {
+		return nil
+	}
+	emb, err := u.embedder.Embed(ctx, last.String())
+	if err != nil {
+		return err
+	}
+	mems, err := u.vector.SearchSimilar(ctx, emb, SearchParams{Limit: 5})
+	if err != nil {
+		return err
+	}
+	for _, m := range mems {
+		task.AddMessage("system", "memory", m.Content)
+		rels, err := u.FindRelated(ctx, m.ID, nil, 5)
+		if err == nil {
+			for _, r := range rels {
+				task.AddMessage("system", "relation", r.Content)
 			}
 		}
 	}
 	return nil
 }
 
-func (unified *UnifiedLongTerm) Recall(task *types.Task) []mcp.Resource {
-	resources := make([]mcp.Resource, 0)
-
-	for _, store := range unified.stores {
-		// Create a buffer to read the store's content
-		buf := new(bytes.Buffer)
-
-		// Read all content from the store
-		if _, err := io.Copy(buf, store); err != nil {
-			continue // Skip this store if there's an error
-		}
-
-		// Create a resource with the store's content
-		resource := mcp.NewResource(
-			"unified",
-			"long-term",
-			mcp.WithResourceDescription("Long-term memory content"),
-			mcp.WithMIMEType("text/plain"),
-		)
-
-		// Set the content data using the appropriate method
-		// We need to use the appropriate method to set content in the resource
-		// This is a placeholder - we need to find the correct way to set content
-		// For now, we'll just add the resource without content
-		resources = append(resources, resource)
+func (u *UnifiedMemory) ExtractMemories(ctx context.Context, task TaskLike) error {
+	msg := task.LastMessage()
+	if msg == nil {
+		return nil
 	}
-
-	return resources
-}
-
-func (unified *UnifiedLongTerm) Forget(task *types.Task) error {
-	for _, store := range unified.stores {
-		if _, err := store.Write([]byte{}); err != nil {
-			return err
-		}
-	}
-	return nil
+	_, err := u.StoreMemory(ctx, msg.String(), map[string]any{"role": msg.Role}, "message")
+	return err
 }

--- a/pkg/stores/qdrant/document.go
+++ b/pkg/stores/qdrant/document.go
@@ -7,6 +7,10 @@ type Document struct {
 }
 
 func NewDocument(id, content string, metadata map[string]any) *Document {
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	metadata["content"] = content
 	return &Document{
 		ID:       id,
 		Content:  content,


### PR DESCRIPTION
## Summary
- implement unified memory interfaces and stores
- add qdrant and neo4j backed stores
- expand a2a task with AddMessage helper
- wire memory injection/extraction into task manager
- enhance qdrant client for payload support

## Testing
- `go build ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified memory system supporting both vector-based and graph-based storage and retrieval of information.
  - Added support for Neo4j as a graph memory store and Qdrant as a vector memory store.
  - Enabled semantic search and relationship-based queries for stored memories.
  - Integrated memory injection and extraction into task workflows, allowing tasks to leverage relevant past information.
- **Improvements**
  - Enhanced document handling and metadata management for improved search and retrieval accuracy.
- **Bug Fixes**
  - Ensured consistent metadata initialization and content storage within memory documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->