### PR TITLE
Add partial streaming support

### DIFF
--- a/pkg/a2a/client.go
+++ b/pkg/a2a/client.go
@@ -95,6 +95,21 @@ func (client *Client) SendTask(params TaskSendParams) (jsonrpc.Response, error) 
 }
 
 /*
+SendTaskSubscribe sends a task message and returns the first streaming result.
+*/
+func (client *Client) SendTaskSubscribe(params TaskSendParams) (jsonrpc.Response, error) {
+	req := jsonrpc.Request{
+		Message: jsonrpc.Message{
+			JSONRPC: "2.0",
+		},
+		Method: "tasks/sendSubscribe",
+		Params: params,
+	}
+
+	return client.doRequest(req)
+}
+
+/*
 GetTask retrieves the status of a task.
 */
 func (client *Client) GetTask(params TaskQueryParams) (jsonrpc.Response, error) {

--- a/pkg/ai/task.go
+++ b/pkg/ai/task.go
@@ -234,9 +234,11 @@ func (manager *TaskManager) StreamTask(
 
 				if err := manager.handleUpdate(params, chunk); err != nil {
 					log.Error("failed to handle update during stream, stopping stream", "task_id", params.ID, "error", err)
-					// Error logged, goroutine will exit, and 'out' will be closed by defer.
-					// The client will see any chunks sent before this error, then the channel closes.
 					return
+				}
+
+				if updErr := manager.taskStore.Update(ctx, params, manager.agent.Name); updErr != nil {
+					log.Error("failed to persist streaming update", "task_id", params.ID, "error", updErr)
 				}
 
 				// Send the processed chunk to the output channel

--- a/pkg/service/agent.go
+++ b/pkg/service/agent.go
@@ -3,6 +3,7 @@ package service
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
 
 	"github.com/charmbracelet/log"
 	"github.com/gofiber/fiber/v3"
@@ -12,6 +13,8 @@ import (
 	"github.com/theapemachine/a2a-go/pkg/ai"
 	"github.com/theapemachine/a2a-go/pkg/errors"
 	"github.com/theapemachine/a2a-go/pkg/jsonrpc"
+	"github.com/theapemachine/a2a-go/pkg/service/sse"
+	"github.com/valyala/fasthttp/fasthttpadaptor"
 )
 
 /*
@@ -19,8 +22,9 @@ A2AServer is safe for concurrent use by default because
 RPCServer & SSEBroker are.
 */
 type A2AServer struct {
-	app   *fiber.App
-	agent *ai.Agent
+	app    *fiber.App
+	agent  *ai.Agent
+	broker *sse.SSEBroker
 }
 
 /*
@@ -33,7 +37,8 @@ func NewAgentServer(agent *ai.Agent) *A2AServer {
 			ServerHeader:      "A2A-Agent-Server",
 			StreamRequestBody: true,
 		}),
-		agent: agent,
+		agent:  agent,
+		broker: sse.NewSSEBroker(),
 	}
 }
 
@@ -41,6 +46,7 @@ func (srv *A2AServer) Start() error {
 	srv.app.Use(logger.New(), healthcheck.NewHealthChecker())
 	srv.app.Get("/", srv.handleRoot)
 	srv.app.Get("/.well-known/agent.json", srv.handleAgentCard)
+	srv.app.Get("/events", srv.handleEvents)
 	srv.app.Post("/rpc", srv.handleRPC)
 	return srv.app.Listen(":3210", fiber.ListenConfig{DisableStartupMessage: true})
 }
@@ -51,6 +57,14 @@ func (srv *A2AServer) handleRoot(ctx fiber.Ctx) error {
 
 func (srv *A2AServer) handleAgentCard(ctx fiber.Ctx) error {
 	return ctx.JSON(srv.agent.Card())
+}
+
+func (srv *A2AServer) handleEvents(ctx fiber.Ctx) error {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		srv.broker.Subscribe(w, r)
+	}
+	fasthttpadaptor.NewFastHTTPHandlerFunc(handler)(ctx.Context())
+	return nil
 }
 
 func (srv *A2AServer) parseParamsWithDecoding(params any) ([]byte, error) {
@@ -122,6 +136,40 @@ func (srv *A2AServer) handleRPC(ctx fiber.Ctx) error {
 
 			return srv.agent.SendTask(ctx.Context(), params)
 		})
+	case "tasks/sendSubscribe":
+		return srv.handleTaskOperation(ctx, request.ID, func() (any, error) {
+			var params a2a.TaskSendParams
+
+			paramsBytes, err := srv.parseParamsWithDecoding(request.Params)
+			if err != nil {
+				return nil, errors.ErrInvalidParams.WithMessagef("failed to parse params: %v", err)
+			}
+
+			if err := json.Unmarshal(paramsBytes, &params); err != nil {
+				log.Error("failed to unmarshal params", "error", err, "params", string(paramsBytes))
+				return nil, errors.ErrInvalidParams.WithMessagef("failed to unmarshal params: %v", err)
+			}
+
+			stream, rpcErr := srv.agent.StreamTask(ctx.Context(), params)
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+
+			var first any
+			select {
+			case first = <-stream:
+			default:
+				first = nil
+			}
+
+			go func() {
+				for evt := range stream {
+					_ = srv.broker.Broadcast(evt)
+				}
+			}()
+
+			return first, nil
+		})
 	case "tasks/get":
 		return srv.handleTaskOperation(ctx, request.ID, func() (any, error) {
 			var params a2a.TaskQueryParams
@@ -154,6 +202,40 @@ func (srv *A2AServer) handleRPC(ctx fiber.Ctx) error {
 			// CancelTask specifically returns nil result on success, and an error on failure.
 			// The handleTaskOperation will correctly wrap this in a JSON-RPC response.
 			return nil, srv.agent.CancelTask(ctx.Context(), params.ID)
+		})
+	case "tasks/resubscribe":
+		return srv.handleTaskOperation(ctx, request.ID, func() (any, error) {
+			var params a2a.TaskQueryParams
+
+			paramsBytes, err := srv.parseParamsWithDecoding(request.Params)
+			if err != nil {
+				return nil, errors.ErrInvalidParams.WithMessagef("failed to parse params: %v", err)
+			}
+
+			if err := json.Unmarshal(paramsBytes, &params); err != nil {
+				log.Error("failed to unmarshal params", "error", err, "params", string(paramsBytes))
+				return nil, errors.ErrInvalidParams.WithMessagef("failed to unmarshal params: %v", err)
+			}
+
+			stream, rpcErr := srv.agent.ResubscribeTask(ctx.Context(), params.ID, *params.HistoryLength)
+			if rpcErr != nil {
+				return nil, rpcErr
+			}
+
+			var first any
+			select {
+			case first = <-stream:
+			default:
+				first = nil
+			}
+
+			go func() {
+				for evt := range stream {
+					_ = srv.broker.Broadcast(evt)
+				}
+			}()
+
+			return first, nil
 		})
 	default:
 		return ctx.Status(fiber.StatusBadRequest).JSON(jsonrpc.Response{

--- a/pkg/ui/app.go
+++ b/pkg/ui/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/theapemachine/a2a-go/pkg/a2a"
 	"github.com/theapemachine/a2a-go/pkg/catalog"
+	"github.com/theapemachine/a2a-go/pkg/sse"
 	"github.com/theapemachine/a2a-go/pkg/stores/s3"
 )
 
@@ -85,6 +86,7 @@ type fetchAgentDetailMsg struct{ agent a2a.AgentCard }
 type fetchTasksMsg struct{ tasks []a2a.Task }
 type fetchTaskDetailMsg struct{ task a2a.Task }
 type errorMsg struct{ err error }
+type streamEventMsg struct{ event any }
 
 // Item implementations for the lists
 type agentItem struct {
@@ -193,6 +195,7 @@ type App struct {
 	agents        []a2a.AgentCard
 	statusMessage string
 	errorMessage  string
+	sseClient     *sse.Client
 }
 
 // NewApp creates a new application with default state


### PR DESCRIPTION
## Summary
- introduce SSE broker to agent server
- add SendTaskSubscribe client helper
- store task updates during streaming

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced real-time task event streaming via server-sent events (SSE), allowing clients to subscribe to live task updates.
  - Added new JSON-RPC methods for subscribing and resubscribing to task events.
  - UI application now includes support for handling incoming SSE events in preparation for real-time updates.

- **Enhancements**
  - Task state is now persisted during streaming, ensuring more reliable tracking of task progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->