### PR TITLE
Add partial streaming support

### DIFF
--- a/pkg/ai/task.go
+++ b/pkg/ai/task.go
@@ -234,9 +234,13 @@ func (manager *TaskManager) StreamTask(
 
 				if err := manager.handleUpdate(params, chunk); err != nil {
 					log.Error("failed to handle update during stream, stopping stream", "task_id", params.ID, "error", err)
-					// Error logged, goroutine will exit, and 'out' will be closed by defer.
-					// The client will see any chunks sent before this error, then the channel closes.
+					// Error logged, goroutine will exit and 'out' will be closed by defer.
+					// The client receives all chunks sent before this error then the channel closes.
 					return
+				}
+
+				if updErr := manager.taskStore.Update(ctx, params, manager.agent.Name); updErr != nil {
+					log.Error("failed to persist streaming update", "task_id", params.ID, "error", updErr)
 				}
 
 				// Send the processed chunk to the output channel


### PR DESCRIPTION
## Summary
- introduce SSE broker to agent server
- add SendTaskSubscribe client helper
- store task updates during streaming
- handle events via SSE

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced real-time event streaming using Server-Sent Events (SSE), allowing users to receive live updates from agents in the UI.
  - Added a new endpoint for subscribing to event streams.
  - Enabled the UI to automatically subscribe to and display live agent events after sending instructions.

- **Bug Fixes**
  - Improved error handling and logging for task state updates during event streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->