### PR TITLE
Add catalog and delegation tools

### DIFF
--- a/cmd/cfg/config.yml
+++ b/cmd/cfg/config.yml
@@ -42,6 +42,8 @@ agent:
       - You should never try to directly respond to the user's request, only relay messages.
     skills:
       - communication
+      - catalog
+      - management
   manager:
     name: "Manager Agent"
     version: "0.1.0"
@@ -243,6 +245,19 @@ skills:
       - "Test the security of the provided server."
       - "Identify the vulnerabilities in the provided code."
       - "Test the code for SQL injection vulnerabilities."
+    input_modes:
+      - "text/plain"
+    output_modes:
+      - "text/plain"
+  catalog:
+    id: "catalog"
+    name: "catalog"
+    description: "Inspect the catalog and list available agents."
+    tags:
+      - "catalog"
+      - "agents"
+    examples:
+      - "List all available agents."
     input_modes:
       - "text/plain"
     output_modes:

--- a/pkg/tools/catalog.go
+++ b/pkg/tools/catalog.go
@@ -1,0 +1,33 @@
+package tools
+
+import (
+    "context"
+    "encoding/json"
+    
+    "github.com/mark3labs/mcp-go/mcp"
+    "github.com/theapemachine/a2a-go/pkg/catalog"
+    "github.com/spf13/viper"
+)
+
+// NewCatalogTool returns a tool definition that lists available agents.
+func NewCatalogTool() *mcp.Tool {
+    tool := mcp.NewTool(
+        "catalog",
+        mcp.WithDescription("List available agents from the catalog"),
+    )
+    return &tool
+}
+
+func executeCatalog(ctx context.Context) (string, error) {
+    url := viper.GetViper().GetString("endpoints.catalog")
+    client := catalog.NewCatalogClient(url)
+    agents, err := client.GetAgents()
+    if err != nil {
+        return "", err
+    }
+    data, err := json.Marshal(agents)
+    if err != nil {
+        return "", err
+    }
+    return string(data), nil
+}

--- a/pkg/tools/delegate.go
+++ b/pkg/tools/delegate.go
@@ -1,0 +1,47 @@
+package tools
+
+import (
+    "context"
+    "encoding/json"
+
+    "github.com/google/uuid"
+    "github.com/mark3labs/mcp-go/mcp"
+    "github.com/theapemachine/a2a-go/pkg/a2a"
+)
+
+// NewDelegateTool returns a tool definition for delegating a task to another agent.
+func NewDelegateTool() *mcp.Tool {
+    tool := mcp.NewTool(
+        "delegate_task",
+        mcp.WithDescription("Delegate a task to another agent"),
+        mcp.WithString("agent", mcp.Description("Agent URL"), mcp.Required()),
+        mcp.WithString("message", mcp.Description("Task message"), mcp.Required()),
+    )
+    return &tool
+}
+
+// delegateParams defines the input for the delegate tool.
+type delegateParams struct {
+    Agent   string `json:"agent"`
+    Message string `json:"message"`
+}
+
+func executeDelegate(ctx context.Context, raw string) (string, error) {
+    var p delegateParams
+    if err := json.Unmarshal([]byte(raw), &p); err != nil {
+        return "", err
+    }
+    client := a2a.NewClient(p.Agent)
+    resp, err := client.SendTask(a2a.TaskSendParams{
+        ID:      uuid.NewString(),
+        Message: a2a.NewTextMessage("user", p.Message),
+    })
+    if err != nil {
+        return "", err
+    }
+    data, err := json.Marshal(resp.Result)
+    if err != nil {
+        return "", err
+    }
+    return string(data), nil
+}

--- a/pkg/tools/mcp.go
+++ b/pkg/tools/mcp.go
@@ -15,20 +15,31 @@ import (
 func Acquire(id string) (*mcp.Tool, error) {
 	log.Info("initializing MCP client")
 
-	switch id {
-	case "development":
-		return NewDockerTool(), nil
-	case "web-browsing":
-		return NewBrowserTool(), nil
-	}
+       switch id {
+       case "development":
+               return NewDockerTool(), nil
+       case "web-browsing":
+               return NewBrowserTool(), nil
+       case "catalog":
+               return NewCatalogTool(), nil
+       case "management":
+               return NewDelegateTool(), nil
+       }
 
 	return nil, fmt.Errorf("tool not found: %s", id)
 }
 
 func NewExecutor(
-	ctx context.Context, name, args string,
+        ctx context.Context, name, args string,
 ) (string, error) {
-	url := viper.GetViper().GetString("endpoints." + name)
+       switch name {
+       case "catalog":
+               return executeCatalog(ctx)
+       case "delegate_task":
+               return executeDelegate(ctx, args)
+       }
+
+       url := viper.GetViper().GetString("endpoints." + name)
 	sseTransport, err := transport.NewSSE(url + "/sse")
 
 	if err != nil {


### PR DESCRIPTION
## Summary
- extend UI agent capabilities via new catalog and delegate tools
- wire tools into acquisition and executor logic
- configure UI agent with catalog and management skills
- document catalog skill in default config

## Testing
- `go test ./...` *(fails: no route to host)*