### PR TITLE
Improve registry concurrency and auth signing

### DIFF
--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGenerateToken(t *testing.T) {
+	Convey("Given an auth service", t, func() {
+		svc := NewService()
+		claims := jwt.MapClaims{"sub": "user1"}
+		tok, err := svc.GenerateToken("Bearer", claims)
+
+		Convey("Then a token is returned", func() {
+			So(err, ShouldBeNil)
+			So(tok.Token, ShouldNotBeEmpty)
+			So(tok.RefreshToken, ShouldNotBeEmpty)
+		})
+	})
+}
+
+func TestAuthenticateRequest(t *testing.T) {
+	Convey("Given a signed request", t, func() {
+		svc := NewService()
+		claims := jwt.MapClaims{"sub": "user1"}
+		tok, _ := svc.GenerateToken("Bearer", claims)
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("Authorization", "Bearer "+tok.Token)
+
+		err := svc.AuthenticateRequest(req)
+
+		Convey("Then authentication succeeds", func() {
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestRefreshToken(t *testing.T) {
+	Convey("Given a valid refresh token", t, func() {
+		svc := NewService()
+		claims := jwt.MapClaims{"sub": "user1"}
+		tok, _ := svc.GenerateToken("Bearer", claims)
+		time.Sleep(10 * time.Millisecond)
+		newTok, err := svc.RefreshToken(tok.RefreshToken)
+
+		Convey("Then a new token is issued", func() {
+			So(err, ShouldBeNil)
+			So(newTok.Token, ShouldNotBeEmpty)
+		})
+	})
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -30,20 +31,25 @@ type ToolDefinition struct {
 }
 
 // toolRegistry holds the registered tool definitions, keyed by SkillID.
-var toolRegistry = make(map[string]ToolDefinition)
-
-// TODO: Add mutex for concurrent access if registration can happen dynamically
+var (
+	toolRegistry = make(map[string]ToolDefinition)
+	registryMu   sync.RWMutex
+)
 
 // RegisterTool adds or updates a tool definition in the central registry.
 // It should typically be called during initialization (e.g., in init() functions).
 func RegisterTool(def ToolDefinition) {
 	// Basic validation could be added here (e.g., ensure SkillID, ToolName, Executor are not empty)
+	registryMu.Lock()
 	toolRegistry[def.SkillID] = def
+	registryMu.Unlock()
 }
 
 // GetToolDefinition retrieves a tool definition from the registry by its SkillID.
 // Returns the definition and a boolean indicating if it was found.
 func GetToolDefinition(skillID string) (ToolDefinition, bool) {
+	registryMu.RLock()
 	def, found := toolRegistry[skillID]
+	registryMu.RUnlock()
 	return def, found
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,40 @@
+package registry
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRegisterTool(t *testing.T) {
+	Convey("Given an empty registry", t, func() {
+		registryMu.Lock()
+		toolRegistry = make(map[string]ToolDefinition)
+		registryMu.Unlock()
+
+		def := ToolDefinition{SkillID: "dev", ToolName: "terminal"}
+		RegisterTool(def)
+
+		Convey("Then the tool can be retrieved", func() {
+			got, ok := GetToolDefinition("dev")
+			So(ok, ShouldBeTrue)
+			So(got.ToolName, ShouldEqual, "terminal")
+		})
+	})
+}
+
+func TestGetToolDefinition(t *testing.T) {
+	Convey("Given a registry with a tool", t, func() {
+		registryMu.Lock()
+		toolRegistry = map[string]ToolDefinition{"dev": {SkillID: "dev", ToolName: "terminal"}}
+		registryMu.Unlock()
+
+		Convey("When retrieving the tool", func() {
+			got, ok := GetToolDefinition("dev")
+			Convey("Then it should exist", func() {
+				So(ok, ShouldBeTrue)
+				So(got.SkillID, ShouldEqual, "dev")
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Summary
- add mutex to registry package for safe concurrent access
- add signing key handling to auth service
- implement tests for registry and auth packages

## Testing
- `go test ./pkg/registry -v`
- `go test ./pkg/auth -v`
- `go test ./...` *(fails: context deadline exceeded)*