### PR TITLE
Expose UI port for host access

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ Use the `Makefile` to run a full containerized distributed system, demonstrating
 make server
 make client
 ```
+
+The `ui` agent is mapped to port `3212`. If you run the TUI outside the Docker
+network, update `agent.ui.url` in `~/.a2a-go/config.yml` to point to
+`http://localhost:3212`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,8 @@ services:
       - CATALOG_URL=http://catalog:3210
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ports:
+      - "3212:3210"
     networks:
       - a2a-network
     depends_on:


### PR DESCRIPTION
## Summary
- expose UI agent on host via docker-compose port mapping
- document UI agent port in README

## Testing
- `go test ./...` *(fails: context deadline due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683d8468c3448326a79afc5cd4fe4200